### PR TITLE
Fix annotation with a limit for dataset over 10 var

### DIFF
--- a/Scripts/CCPM_filtering_dataset.py
+++ b/Scripts/CCPM_filtering_dataset.py
@@ -111,15 +111,6 @@ def main():
     raw_df = load_df_in_any_format(args.in_dataset)
     descriptive_columns = [n for n in range(0, args.nb_descriptive_columns)]
 
-    # Validating low number of variables for --annotate option.
-    if args.annotate:
-        if len(raw_df.columns) > 10:
-            logging.warning('Due to high number of variables, annotating heatmap is deactivated. Annotation is only \n'
-                            'available for dataset with 10 or less variables.')
-            annotate = False
-        else:
-            annotate = True
-
     # Removing NaNs from dataset and saving the rows in a different file.
     logging.info('Filtering dataset to remove NaN values. ')
     nans, clean = remove_nans(raw_df)
@@ -148,8 +139,16 @@ def main():
 
         # Plotting heatmap and computing correlation matrix.
         logging.info('Generating correlation matrix and heatmap.')
-        corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
-                                                   font_scale=args.font_scale, cmap=args.cmap, annot=annotate)
+        if args.annotate:
+            if len(raw_df.columns) > 10:
+                logging.warning('Due to high number of variables, annotating heatmap is deactivated. Annotation is \n '
+                                'only available for dataset with 10 or less variables.')
+            corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
+                                                       font_scale=args.font_scale, cmap=args.cmap,
+                                                       annot=True if len(raw_df.columns) > 10 else False)
+        else:
+            corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
+                                                       font_scale=args.font_scale, cmap=args.cmap)
 
     corr_mat.to_excel(f'{args.out_folder}/correlation_coefficient.xlsx', header=True, index=True)
 

--- a/Scripts/CCPM_filtering_dataset.py
+++ b/Scripts/CCPM_filtering_dataset.py
@@ -111,6 +111,15 @@ def main():
     raw_df = load_df_in_any_format(args.in_dataset)
     descriptive_columns = [n for n in range(0, args.nb_descriptive_columns)]
 
+    # Validating low number of variables for --annotate option.
+    if args.annotate:
+        if len(raw_df.columns) > 10:
+            logging.warning('Due to high number of variables, annotating heatmap is deactivated. Annotation is only \n'
+                            'available for dataset with 10 or less variables.')
+            annotate = False
+        else:
+            annotate = True
+
     # Removing NaNs from dataset and saving the rows in a different file.
     logging.info('Filtering dataset to remove NaN values. ')
     nans, clean = remove_nans(raw_df)
@@ -140,7 +149,7 @@ def main():
         # Plotting heatmap and computing correlation matrix.
         logging.info('Generating correlation matrix and heatmap.')
         corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
-                                                   font_scale=args.font_scale, cmap=args.cmap, annot=args.annotate)
+                                                   font_scale=args.font_scale, cmap=args.cmap, annot=annotate)
 
     corr_mat.to_excel(f'{args.out_folder}/correlation_coefficient.xlsx', header=True, index=True)
 

--- a/Scripts/CCPM_filtering_dataset.py
+++ b/Scripts/CCPM_filtering_dataset.py
@@ -145,7 +145,7 @@ def main():
                                 'only available for dataset with 10 or less variables.')
             corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
                                                        font_scale=args.font_scale, cmap=args.cmap,
-                                                       annot=True if len(raw_df.columns) > 10 else False)
+                                                       annot=False if len(raw_df.columns) > 10 else True)
         else:
             corr_mat = compute_correlation_coefficient(variable_to_plot, args.out_folder, context=args.context,
                                                        font_scale=args.font_scale, cmap=args.cmap)


### PR DESCRIPTION
Option to annotate heatmap with correlation values isn't feasible with high number of variables in a dataset. Limit the use of this option to dataset with maximum of 10 variables. 