### PR TITLE
Adding support for multiple dataframe as input

### DIFF
--- a/CCPM/io/utils.py
+++ b/CCPM/io/utils.py
@@ -2,13 +2,16 @@ import inspect
 import os
 import shutil
 
-import pandas as pd
+from detect_delimiter import detect
 from fpdf import FPDF
+import pandas as pd
+
 
 """
 Some function comes from the scilpy toolbox. Please see : 
 https://github.com/scilus/scilpy
 """
+
 
 def load_df_in_any_format(file):
     """
@@ -22,6 +25,11 @@ def load_df_in_any_format(file):
         df = pd.read_csv(file)
     if ext == '.xlsx':
         df = pd.read_excel(file)
+    if ext == '.txt':
+        with open(file, 'r') as f:
+            f = f.read()
+            delimiter = detect(f, whitelist=['\t', ':', ';', ' ', ','])
+        df = pd.read_csv(file, sep=delimiter)
 
     return df
 

--- a/CCPM/utils/preprocessing.py
+++ b/CCPM/utils/preprocessing.py
@@ -89,3 +89,27 @@ def compute_correlation_coefficient(df, out_folder, context='poster', font_scale
     plt.savefig(f'{out_folder}/correlation_heatmap.png')
 
     return corr_mat
+
+
+def merge_dataframes(dict_df, index, repeated_columns=False):
+    """
+    Function to merge a variable number of dataframe by matching the values of a specific column (hereby
+    labeled as index.) Index values must appear only once in the dataframe for the function to work.
+    :param dict_df:             Dictionary of pandas dataframe.
+    :param index:               String of the name of the column to use as index (needs to be the same across all dataframes).
+    :param repeated_columns     Flag to use if column name are repeated across dataframe to merge.
+    :return:                    Joint large pandas dataframe.
+    """
+
+    keys = list(dict_df.keys())
+    for k in keys:
+        dict_df[k] = dict_df[k].set_index(f'{index}')
+
+    if repeated_columns:
+        out = dict_df[keys[0]]
+        for k in keys[1:len(keys)]:
+            out = out.join(dict_df[k], lsuffix='a', rsuffix='b')
+    else:
+        out = dict_df[keys[0]].join([dict_df[k] for k in keys[1:len(keys)]])
+
+    return out

--- a/Scripts/CCPM_filtering_dataset.py
+++ b/Scripts/CCPM_filtering_dataset.py
@@ -123,7 +123,7 @@ def main():
         dict_df = {i: load_df_in_any_format(i) for i in args.in_dataset}
         raw_df = merge_dataframes(dict_df, args.identifier_column)
     else:
-        raw_df = load_df_in_any_format(args.in_dataset)
+        raw_df = load_df_in_any_format(args.in_dataset[0])
     descriptive_columns = [n for n in range(0, args.nb_descriptive_columns)]
 
     # Removing NaNs from dataset and saving the rows in a different file.

--- a/Scripts/CCPM_filtering_dataset.py
+++ b/Scripts/CCPM_filtering_dataset.py
@@ -13,24 +13,28 @@
 =============================================================================
 
 CCPM_filtering_dataset is designed to compute basic statistics, plotting
-distributions graphs and correlation matrix of raw data.
+distributions and correlation matrix of raw data.
 
-Initial filtering and evaluating steps are:
+Filtering and evaluating steps are:
     1)  Removing rows containing NaNs. (2 dataframes will be outputted, one
         with the cleaned dataset and one with the excluded rows.) Both files
         should be validated after running this script to ensure correct filtering.
-    2)  Computing global basic statistics. Stats included are : count, mean, std, min,
-        25%, 50%, 75%, max, Wilk and Wilk p-values.
+    2)  Computing global basic statistics for each variable. Stats included are : count, mean,
+        std, min, 25%, 50%, 75%, max, Wilk and Wilk p-values.
     3)  Plotting distributions graph. 2 plots are outputted : histogram with kde and
         ecdf plot.
     4)  Computing correlation matrix. Correlation between all variables from the dataset
         is computed and plotted as a heatmap.
     5)  Final pdf file with indications based on descriptive statistics is outputted (if --report
-        is selected). Indications will highlight variables with W statistic < 0.95 and pair of variables
-        with pearson value > 0.8.
+        is selected). Indications will highlight variables with W statistic < 0.95 and pair
+        of variables with pearson value > 0.8.
 
 Manual evaluation of all outputted results is recommended to ensure the script behaved
 correctly.
+
+When inputting multiple dataset, users must validate that the index used (for example
+subject's id) appear only once in a single dataframe. Otherwise, merging dataframe will
+not behave correctly and index will not be aligned.
 
 EXAMPLE USAGE :
 CCPM_filtering_dataset.py -i FILE -o OUT_FOLDER -n 1
@@ -53,7 +57,8 @@ from CCPM.io.utils import (load_df_in_any_format,
 from CCPM.utils.preprocessing import (remove_nans,
                                       plot_distributions,
                                       compute_shapiro_wilk_test,
-                                      compute_correlation_coefficient)
+                                      compute_correlation_coefficient,
+                                      merge_dataframes)
 
 
 def _build_arg_parser():
@@ -61,13 +66,15 @@ def _build_arg_parser():
         description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
 
-    p.add_argument('-i', '--in_dataset', metavar='FILE', required=True,
+    p.add_argument('-i', '--in_dataset', metavar='FILE', required=True, nargs='+',
                    help='Dataset containing raw data all variables for all subjects.')
     p.add_argument('-o', '--out_folder', required=True,
                    help='Directory in which datasets, plots and statistics will be saved.')
     p.add_argument('-n', '--nb_descriptive_columns', type=int, required=True,
                    help='Number of descriptive columns at the beginning of the dataset to exclude in \n'
                         'statistics and descriptive tables.')
+    p.add_argument('--identifier_column',
+                   help='Column name containing the subject ids. (Necessary when merging multiple dataframe.')
     p.add_argument('--disable_plotting', action='store_true',
                    help='If used, will disable all plotting and simply output tables.')
 
@@ -108,7 +115,15 @@ def main():
     assert_input(parser, args.in_dataset)
     assert_output_dir_exist(parser, args, args.out_folder, create_dir=True)
 
-    raw_df = load_df_in_any_format(args.in_dataset)
+    # Loading dataframe.
+    logging.info('Loading dataset(s)...')
+    if len(args.in_dataset) > 1:
+        if args.identifier_column is None:
+            parser.error('Column name for index matching is required when inputting multiple dataframe.')
+        dict_df = {i: load_df_in_any_format(i) for i in args.in_dataset}
+        raw_df = merge_dataframes(dict_df, args.identifier_column)
+    else:
+        raw_df = load_df_in_any_format(args.in_dataset)
     descriptive_columns = [n for n in range(0, args.nb_descriptive_columns)]
 
     # Removing NaNs from dataset and saving the rows in a different file.
@@ -116,7 +131,7 @@ def main():
     nans, clean = remove_nans(raw_df)
 
     # Exporting global description statistics.
-    variable_for_stats = clean.drop(clean.columns[descriptive_columns], axis=1, inplace=False)
+    variable_for_stats = clean.drop(clean.columns[descriptive_columns], axis=1, inplace=False).astype('float')
     logging.info('Computing global descriptive statistics.')
     description_df = variable_for_stats.describe()
     wilk, pvalues = compute_shapiro_wilk_test(variable_for_stats)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ seaborn==0.12.2
 pytest-console-scripts==1.3.1
 gdown==4.6.4
 fpdf==1.7.2
+detect-delimiter==0.1.1


### PR DESCRIPTION
Enable the function to merge dataset according to an identifier column (subject's id, etc.). Useful in cases where data is spread out across multiple dataframes (for example : ABCD data).