### PR TITLE
[ENH] Remove the need for datasets once graph file is generated. 

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Pytest
         run: |
           source $(poetry env info --path)/bin/activate
-          pytest --cov=./ --cov-report=xml
+          pytest --cov=./ --cov-report=xml -v
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         env:

--- a/CCPM/cli/ComputeGraphNetwork.py
+++ b/CCPM/cli/ComputeGraphNetwork.py
@@ -11,7 +11,7 @@ from typing_extensions import Annotated
 
 from CCPM.io.utils import (assert_input, assert_output_dir_exist,
                            load_df_in_any_format)
-from CCPM.network.utils import get_nodes_and_edges
+from CCPM.network.utils import get_nodes_and_edges, construct_attributes_dict
 from CCPM.network.viz import (
     compute_layout,
     set_nodes_position,
@@ -82,6 +82,13 @@ def ComputeGraphNetwork(
         Parameter(
             show_default=True,
             group="Plotting Options",
+        ),
+    ] = False,
+    import_data: Annotated[
+        bool,
+        Parameter(
+            show_default=True,
+            group="Essential Files Options",
         ),
     ] = False,
     layout: Annotated[
@@ -168,6 +175,9 @@ def ComputeGraphNetwork(
         If true, save the parameters used in a .txt file.
     plot_distribution : bool, optional
         If true, will plot the membership distribution and delta.
+    import_data : bool, optional
+        If true, will import the data from the input dataset within the graph
+        network file.
     layout : NetworkLayout, optional
         Layout algorithm to determine the nodes position.
     weight : str, optional
@@ -219,6 +229,13 @@ def ComputeGraphNetwork(
 
     logging.info("Setting nodes position.")
     set_nodes_position(G, pos)
+
+    if import_data:
+        logging.info("Importing data within the .gml file.")
+        attributes = construct_attributes_dict(desc_data,
+                                               desc_data.columns[1:],
+                                               id_column)
+        nx.set_node_attributes(G, attributes)
 
     # Saving graph as a .gexf object for easy reloading.
     nx.write_gml(G, f"{out_folder}/network_graph_file.gml")

--- a/CCPM/cli/FuzzyClustering.py
+++ b/CCPM/cli/FuzzyClustering.py
@@ -577,7 +577,7 @@ def FuzzyClustering(
         )
 
         # Appending subject ids and descriptive columns.
-        member_out = pd.concat([desc_data, member], axis=1)
+        member_out = pd.concat([raw_df, member], axis=1)
         member_out.to_excel(
             f"{out_folder}/MEMBERSHIP_DF/clusters_membership_{i+2}.xlsx",
             header=True,

--- a/CCPM/network/metrics.py
+++ b/CCPM/network/metrics.py
@@ -169,7 +169,6 @@ def weightedpath(
     graph,
     df,
     label_name,
-    id_column,
     iterations=1000,
     weight=None,
     method="dijkstra",
@@ -187,8 +186,6 @@ def weightedpath(
         df (pandas.DataFrame):                  Dataframe containing the nodes
         label_name (str):                       Name of the column containing
                                                 the group label.
-        id_column (str):                        Name of the column containing
-                                                the nodes IDs.
         iterations (int, optional):             Number of iterations to run.
                                                 Defaults to 1000.
         weight (str, optional):                 Edge attributes to use as
@@ -208,7 +205,7 @@ def weightedpath(
     """
     # Setting lists.
     group_exclude = df.loc[df[label_name] == 0]
-    nodes_exclude = group_exclude[id_column].to_list()
+    nodes_exclude = group_exclude.index.to_list()
     nodes_include = [node for node in list(graph) if node not in nodes_exclude]
 
     logging.info("Computing weighted path for the set of nodes.")
@@ -218,7 +215,7 @@ def weightedpath(
     )
 
     # Fetching all possible nodes.
-    nodes_list = df[id_column].to_list()
+    nodes_list = df.index.to_list()
 
     # Setting partial function to pass common arguments between iterations.
     if distribution is None:

--- a/CCPM/tests/test_compare_graphs.py
+++ b/CCPM/tests/test_compare_graphs.py
@@ -20,13 +20,12 @@ def test_help(script_runner):
 def test_compute_graph_network(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_graph = os.path.join(get_home(), "data/graph_file.gml")
-    in_mat = os.path.join(get_home(), "data/clusters_membership_3.npy")
     out_folder = os.path.join(get_home(), "data/compare_graph/")
 
     ret = script_runner.run([
         "CompareGraphs",
         "--in-graph1", in_graph,
-        "--in-matrix", in_mat,
+        "--weight", "membership",
         "--percentile", 80,
         "--in-graph2", in_graph,
         "--out-folder", out_folder,

--- a/CCPM/tests/test_compute_graph_network.py
+++ b/CCPM/tests/test_compute_graph_network.py
@@ -28,6 +28,7 @@ def test_compute_graph_network(script_runner):
         "--out-folder", out_folder,
         "--id-column", "subjectkey",
         "--plot-distribution",
+        "--import-data",
         "--desc-columns", 1, "-f"]
     )
 

--- a/CCPM/tests/test_compute_weighted_path.py
+++ b/CCPM/tests/test_compute_weighted_path.py
@@ -25,7 +25,6 @@ def test_compute_weighted_path(script_runner):
     ret = script_runner.run([
         "AverageWeightedPath",
         "--in-graph", in_graph,
-        "--id-column", "subjectkey",
         "--label-name", "diagnosis",
         "--out-folder", out_folder,
         "--iterations", 10,

--- a/CCPM/tests/test_compute_weighted_path.py
+++ b/CCPM/tests/test_compute_weighted_path.py
@@ -20,13 +20,11 @@ def test_help(script_runner):
 def test_compute_weighted_path(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_graph = os.path.join(get_home(), "data/graph_file.gml")
-    data_label = os.path.join(get_home(), "data/labels.xlsx")
     out_folder = os.path.join(get_home(), "data/weighted_path/")
 
     ret = script_runner.run([
         "AverageWeightedPath",
         "--in-graph", in_graph,
-        "--data-for-label", data_label,
         "--id-column", "subjectkey",
         "--label-name", "diagnosis",
         "--out-folder", out_folder,

--- a/CCPM/tests/test_visualize_graph.py
+++ b/CCPM/tests/test_visualize_graph.py
@@ -20,7 +20,6 @@ def test_help(script_runner):
 def test_visualize_graph_network(script_runner):
     os.chdir(os.path.expanduser(tmp_dir.name))
     in_graph = os.path.join(get_home(), "data/graph_file.gml")
-    data_label = os.path.join(get_home(), "data/labels.xlsx")
     out_folder = os.path.join(get_home(), "data/Visualize_graph/")
 
     ret = script_runner.run([
@@ -28,8 +27,6 @@ def test_visualize_graph_network(script_runner):
         "--in-graph", in_graph,
         "--out-folder", out_folder,
         "--weight", "membership",
-        "--data-for-label", data_label,
-        "--id-column", "subjectkey",
         "--label-name", "diagnosis",
         "-f", "-v", "-s"]
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ style = "semver"
 
 [tool.poetry]
 name = "CCPM"
-version = "0.0.0-post.282+3ca4a21"
+version = "0.0.0-post.289+9ec052a"
 description = "Children Cognitive Profiles Mapping Toolbox (CCPM)"
 authors = ["Anthony Gagnon <anthony.gagnon7@usherbrooke.ca>"]
 documentation = "https://gagnonanthony.github.io/CCPM/"


### PR DESCRIPTION
To solve issue #39. As of now, the graph file becomes the main data object for this package, once it is generated using ComputeGraphNetwork, every operation will be done using this file type. 

Main advantages:

- Secure data handling with a low risk of mixing up data between subjects. 
- Easier to combine statistics with visualization and plotting options.

Closes #39 